### PR TITLE
Require log in to access most pages

### DIFF
--- a/packages/client/src/components/AuthProvider.tsx
+++ b/packages/client/src/components/AuthProvider.tsx
@@ -2,8 +2,15 @@ import { Navigate } from "react-router-dom";
 import { useAuth } from "@/hooks/use-auth";
 
 export function RequireAuth({ children }: { children?: React.ReactNode }) {
-	const { isAuthenticated } = useAuth();
+	const { isAuthenticated, isLoading } = useAuth();
 
-	if (!isAuthenticated) return <Navigate to="/login" replace />;
+	if (isLoading) {
+		return <div>Loading...</div>;
+	}
+
+	if (!isAuthenticated) {
+		return <Navigate to="/login" replace />;
+	}
+
 	return <>{children}</>;
 }

--- a/packages/client/src/components/Navbar.tsx
+++ b/packages/client/src/components/Navbar.tsx
@@ -1,4 +1,5 @@
-import { HStack, Image } from "@chakra-ui/react";
+import { HStack, IconButton, Image } from "@chakra-ui/react";
+import { LuCircleUserRound } from "react-icons/lu";
 import { NavigationMenu, NavigationMenuItem, NavigationMenuLink } from "@/components/ui/navigation-menu";
 import { AuthDialog } from "./ui/AuthDialog";
 import { ColorModeButton } from "./ui/color-mode";
@@ -34,7 +35,11 @@ function Navbar() {
 			<NavigationMenuItem>
 				<HStack gap={4}>
 					<ColorModeButton color="white"></ColorModeButton>
-					<AuthDialog />
+					<AuthDialog>
+						<IconButton bg="primary" _dark={{ bg: "primary", color: "white" }}>
+							<LuCircleUserRound />
+						</IconButton>
+					</AuthDialog>
 				</HStack>
 			</NavigationMenuItem>
 		</NavigationMenu>

--- a/packages/client/src/components/ui/AuthDialog.tsx
+++ b/packages/client/src/components/ui/AuthDialog.tsx
@@ -1,7 +1,6 @@
-import { Button, CloseButton, Dialog, Field, Flex, IconButton, Input, Portal, Text } from "@chakra-ui/react";
+import { Button, CloseButton, Dialog, Field, Flex, Input, Portal, Text } from "@chakra-ui/react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
-import { LuCircleUserRound } from "react-icons/lu";
 import { signIn, signUp } from "@/lib/auth";
 import { PasswordInput } from "./password-input";
 

--- a/packages/client/src/components/ui/AuthDialog.tsx
+++ b/packages/client/src/components/ui/AuthDialog.tsx
@@ -133,17 +133,17 @@ const LoginForm = ({ isRegistering, setIsRegistering, registerSuccess, setRegist
 	);
 };
 
-export const AuthDialog = () => {
+interface AuthDialogProps {
+	children: React.ReactNode;
+}
+
+export const AuthDialog = ({ children }: AuthDialogProps) => {
 	const [isRegistering, setIsRegistering] = useState(false);
 	const [registerSuccess, setRegisterSuccess] = useState("");
 
 	return (
 		<Dialog.Root>
-			<Dialog.Trigger asChild>
-				<IconButton bg="primary" _dark={{ bg: "primary", color: "white" }}>
-					<LuCircleUserRound></LuCircleUserRound>
-				</IconButton>
-			</Dialog.Trigger>
+			<Dialog.Trigger asChild>{children}</Dialog.Trigger>
 			<Portal>
 				<Dialog.Backdrop />
 				<Dialog.Positioner>

--- a/packages/client/src/hooks/use-auth.ts
+++ b/packages/client/src/hooks/use-auth.ts
@@ -1,12 +1,11 @@
 import { useSession } from "@/lib/auth";
 
 export function useAuth() {
-	const { data } = useSession();
+	const { data, isPending } = useSession();
 
-	const isAuthenticated = (() => {
-		if (!data) return true;
-		return true;
-	})();
-
-	return { isAuthenticated };
+	return {
+		user: data,
+		isLoading: isPending,
+		isAuthenticated: !isPending && !!data,
+	};
 }

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -25,8 +25,25 @@ const router = createBrowserRouter([
 		element: <App></App>,
 		children: [
 			{
+				index: true,
+				element: <HomePage />,
+			},
+			{
 				path: "login",
 				element: <LoginPage />,
+			},
+			{
+				path: "tools",
+				children: [
+					{
+						index: true,
+						element: <ToolIndexMainMenuPage />,
+					},
+					{
+						path: "index",
+						element: <ToolIndexPage />,
+					},
+				],
 			},
 			{
 				element: (
@@ -35,10 +52,6 @@ const router = createBrowserRouter([
 					</RequireAuth>
 				),
 				children: [
-					{
-						index: true,
-						element: <HomePage />,
-					},
 					{
 						path: "community",
 						children: [
@@ -63,14 +76,6 @@ const router = createBrowserRouter([
 					{
 						path: "tools",
 						children: [
-							{
-								index: true,
-								element: <ToolIndexMainMenuPage />,
-							},
-							{
-								path: "index",
-								element: <ToolIndexPage />,
-							},
 							{
 								path: "submit",
 								element: <ToolSubmissionPage />,

--- a/packages/client/src/pages/LoginPage.tsx
+++ b/packages/client/src/pages/LoginPage.tsx
@@ -1,3 +1,4 @@
+import { Button, Heading, Stack } from "@chakra-ui/react";
 import { Navigate } from "react-router-dom";
 import { AuthDialog } from "@/components/ui/AuthDialog";
 import { useAuth } from "@/hooks/use-auth";
@@ -7,5 +8,15 @@ export const LoginPage = () => {
 
 	if (isAuthenticated) return <Navigate to="/" replace />;
 
-	return <AuthDialog />;
+	return (
+		<Stack align="center" textAlign="center" gap="6">
+			<Heading as="h1" size="4xl">
+				You must be logged in to access this page.
+			</Heading>
+
+			<AuthDialog>
+				<Button bg="primary">Log in / Sign up</Button>
+			</AuthDialog>
+		</Stack>
+	);
 };


### PR DESCRIPTION
Per Yoonha, all pages except home page and tool index should be auth-gated. This should've been working already, but our hook was broken. This PR fixes the hook, changes which paths are auth-gated, and redesigns the requires auth/login page.

Merging to save time and since #25 is blocked by it