### PR TITLE
Admin view for tool approvals

### DIFF
--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -24,10 +24,15 @@ type ActionType = "approve" | "reject";
 function ToolModerationTab() {
 	const [tools, setTools] = useState<PendingTool[]>([]);
 	const [loading, setLoading] = useState(true);
-	const [selectedTool, setSelectedTool] = useState<PendingTool | null>(null);
-	const [action, setAction] = useState<ActionType | null>(null);
 	const [submitting, setSubmitting] = useState(false);
-	const [detailTool, setDetailTool] = useState<PendingTool | null>(null);
+
+	// Detail dialog
+	const [detailOpen, setDetailOpen] = useState(false);
+	const [detailContent, setDetailContent] = useState<PendingTool | null>(null);
+
+	// Confirm dialog
+	const [confirmOpen, setConfirmOpen] = useState(false);
+	const [confirmContent, setConfirmContent] = useState<{ tool: PendingTool; action: ActionType } | null>(null);
 
 	useEffect(() => {
 		const fetchPending = async () => {
@@ -44,26 +49,27 @@ function ToolModerationTab() {
 		fetchPending();
 	}, []);
 
-	const openDialog = (tool: PendingTool, actionType: ActionType) => {
-		setSelectedTool(tool);
-		setAction(actionType);
+	const openDetailDialog = (tool: PendingTool) => {
+		setDetailContent(tool);
+		setDetailOpen(true);
 	};
 
-	const closeDialog = () => {
-		setSelectedTool(null);
-		setAction(null);
+	const openConfirmDialog = (tool: PendingTool, action: ActionType) => {
+		setConfirmContent({ tool, action });
+		setConfirmOpen(true);
 	};
 
 	const handleConfirm = async () => {
-		if (!selectedTool || !action) return;
+		if (!confirmContent) return;
+		const { tool, action } = confirmContent;
 		setSubmitting(true);
 		try {
-			await fetch(api(`/api/admin/tools/${selectedTool.slug}/${action}`), {
+			await fetch(api(`/api/admin/tools/${tool.slug}/${action}`), {
 				method: "POST",
 				credentials: "include",
 			});
-			setTools((prev) => prev.filter((t) => t._id !== selectedTool._id));
-			closeDialog();
+			setTools((prev) => prev.filter((t) => t._id !== tool._id));
+			setConfirmOpen(false);
 		} catch (err) {
 			console.error("Failed to update tool:", err);
 		} finally {
@@ -91,7 +97,7 @@ function ToolModerationTab() {
 							<Table.Cell>{tool.name}</Table.Cell>
 							<Table.Cell>{tool.email}</Table.Cell>
 							<Table.Cell>
-								<Button variant="subtle" size="sm" onClick={() => setDetailTool(tool)}>
+								<Button variant="subtle" size="sm" onClick={() => openDetailDialog(tool)}>
 									More Details
 								</Button>
 							</Table.Cell>
@@ -101,7 +107,7 @@ function ToolModerationTab() {
 										size="sm"
 										bg="green.500"
 										variant="subtle"
-										onClick={() => openDialog(tool, "approve")}
+										onClick={() => openConfirmDialog(tool, "approve")}
 									>
 										<LuCheck /> Approve
 									</Button>
@@ -109,7 +115,7 @@ function ToolModerationTab() {
 										size="sm"
 										bg="red.400"
 										variant="subtle"
-										onClick={() => openDialog(tool, "reject")}
+										onClick={() => openConfirmDialog(tool, "reject")}
 									>
 										<LuX /> Reject
 									</Button>
@@ -120,18 +126,14 @@ function ToolModerationTab() {
 				</Table.Body>
 			</Table.Root>
 
-			<Dialog.Root
-				open={!!detailTool}
-				onOpenChange={({ open }) => {
-					if (!open) setDetailTool(null);
-				}}
-			>
+			{/* Detail dialog */}
+			<Dialog.Root open={detailOpen} onOpenChange={({ open }) => setDetailOpen(open)}>
 				<Portal>
 					<Dialog.Backdrop />
 					<Dialog.Positioner>
 						<Dialog.Content maxWidth="600px">
 							<Dialog.Header>
-								<Dialog.Title>{detailTool?.name}</Dialog.Title>
+								<Dialog.Title>{detailContent?.name}</Dialog.Title>
 							</Dialog.Header>
 							<Dialog.Body>
 								<Stack gap={4}>
@@ -139,24 +141,24 @@ function ToolModerationTab() {
 										<Text fontWeight="bold" mb={1}>
 											Description
 										</Text>
-										<Text>{detailTool?.description}</Text>
+										<Text>{detailContent?.description}</Text>
 									</Box>
 									{[
 										{
 											label: "Link",
-											value: detailTool?.link ? decodeEntities(detailTool.link) : undefined,
+											value: detailContent?.link ? decodeEntities(detailContent.link) : undefined,
 										},
-										{ label: "Submitted By", value: detailTool?.email },
-										{ label: "Compatibility", value: detailTool?.compatibility },
-										{ label: "Videos", value: detailTool?.videos },
-										{ label: "Guidelines", value: detailTool?.guidelines },
-										{ label: "Limits", value: detailTool?.limits },
-										{ label: "Comments", value: detailTool?.comments },
-										{ label: "Is Creator", value: detailTool?.isCreator ? "Yes" : "No" },
+										{ label: "Submitted By", value: detailContent?.email },
+										{ label: "Compatibility", value: detailContent?.compatibility },
+										{ label: "Videos", value: detailContent?.videos },
+										{ label: "Guidelines", value: detailContent?.guidelines },
+										{ label: "Limits", value: detailContent?.limits },
+										{ label: "Comments", value: detailContent?.comments },
+										{ label: "Is Creator", value: detailContent?.isCreator ? "Yes" : "No" },
 										{
 											label: "Submitted",
-											value: detailTool
-												? new Date(detailTool.createdAt).toLocaleString("en-US", {
+											value: detailContent
+												? new Date(detailContent.createdAt).toLocaleString("en-US", {
 														month: "long",
 														day: "numeric",
 														year: "numeric",
@@ -185,7 +187,7 @@ function ToolModerationTab() {
 								</Stack>
 							</Dialog.Body>
 							<Dialog.Footer>
-								<Button variant="ghost" onClick={() => setDetailTool(null)}>
+								<Button variant="ghost" onClick={() => setDetailOpen(false)}>
 									Close
 								</Button>
 							</Dialog.Footer>
@@ -194,38 +196,38 @@ function ToolModerationTab() {
 				</Portal>
 			</Dialog.Root>
 
-			<Dialog.Root
-				open={!!selectedTool}
-				onOpenChange={({ open }) => {
-					if (!open) closeDialog();
-				}}
-			>
+			{/* Confirm dialog */}
+			<Dialog.Root open={confirmOpen} onOpenChange={({ open }) => setConfirmOpen(open)}>
 				<Portal>
 					<Dialog.Backdrop />
 					<Dialog.Positioner>
 						<Dialog.Content>
 							<Dialog.Header>
-								<Dialog.Title>{action === "approve" ? "Approve Tool" : "Reject Tool"}</Dialog.Title>
+								<Dialog.Title>
+									{confirmContent?.action === "approve" ? "Approve Tool" : "Reject Tool"}
+								</Dialog.Title>
 							</Dialog.Header>
 							<Dialog.Body>
 								<Text>
 									Are you sure you want to{" "}
-									<Badge colorScheme={action === "approve" ? "green" : "red"}>{action}</Badge>{" "}
-									<strong>{selectedTool?.name}</strong>?
-									{action === "reject" &&
+									<Badge color={confirmContent?.action === "approve" ? "green" : "red"}>
+										{confirmContent?.action}
+									</Badge>{" "}
+									<strong>{confirmContent?.tool.name}</strong>?
+									{confirmContent?.action === "reject" &&
 										" This will mark it as rejected and hide it from the public index."}
 								</Text>
 							</Dialog.Body>
 							<Dialog.Footer>
-								<Button variant="ghost" onClick={closeDialog} disabled={submitting}>
+								<Button variant="ghost" onClick={() => setConfirmOpen(false)} disabled={submitting}>
 									Cancel
 								</Button>
 								<Button
-									colorScheme={action === "approve" ? "green" : "red"}
+									bg={confirmContent?.action === "approve" ? "green.500" : "red.400"}
 									onClick={handleConfirm}
 									loading={submitting}
 								>
-									Confirm {action === "approve" ? "Approval" : "Rejection"}
+									Confirm {confirmContent?.action === "approve" ? "Approval" : "Rejection"}
 								</Button>
 							</Dialog.Footer>
 						</Dialog.Content>

--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -1,10 +1,188 @@
-import { Heading, Stack, Text } from "@chakra-ui/react";
+import { Badge, Button, Dialog, Heading, HStack, Link, Portal, Stack, Table, Tabs, Text } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import { LuCheck, LuX } from "react-icons/lu";
+import { api } from "@/lib/utils";
+
+interface PendingTool {
+	_id: string;
+	slug: string;
+	name: string;
+	description: string;
+	link: string;
+	email: string;
+	compatibility?: string;
+	createdAt: string;
+}
+
+type ActionType = "approve" | "reject";
+
+function ToolModerationTab() {
+	const [tools, setTools] = useState<PendingTool[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [selectedTool, setSelectedTool] = useState<PendingTool | null>(null);
+	const [action, setAction] = useState<ActionType | null>(null);
+	const [submitting, setSubmitting] = useState(false);
+
+	useEffect(() => {
+		const fetchPending = async () => {
+			try {
+				const res = await fetch(api("/api/admin/tools/pending"), {
+					credentials: "include",
+				});
+				const data = await res.json();
+				setTools(data);
+			} catch (err) {
+				console.error("Failed to fetch pending tools:", err);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		fetchPending();
+	}, []);
+
+	const openDialog = (tool: PendingTool, actionType: ActionType) => {
+		setSelectedTool(tool);
+		setAction(actionType);
+	};
+
+	const closeDialog = () => {
+		setSelectedTool(null);
+		setAction(null);
+	};
+
+	const handleConfirm = async () => {
+		if (!selectedTool || !action) return;
+		setSubmitting(true);
+		try {
+			await fetch(api(`/api/admin/tools/${selectedTool.slug}/${action}`), {
+				method: "POST",
+				credentials: "include",
+			});
+			setTools((prev) => prev.filter((t) => t._id !== selectedTool._id));
+			closeDialog();
+		} catch (err) {
+			console.error("Failed to update tool:", err);
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	if (loading) return <Text>Loading pending tools...</Text>;
+	if (tools.length === 0) return <Text color="fg.muted">No pending tools to review.</Text>;
+
+	return (
+		<>
+			<Table.Root size="lg" variant="outline" showColumnBorder css={{ "--chakra-colors-border": "#5B5B5B" }}>
+				<Table.Header>
+					<Table.Row bg="secondary">
+						<Table.ColumnHeader>Name</Table.ColumnHeader>
+						<Table.ColumnHeader>Submitted By</Table.ColumnHeader>
+						<Table.ColumnHeader>Compatibility</Table.ColumnHeader>
+						<Table.ColumnHeader>Description</Table.ColumnHeader>
+						<Table.ColumnHeader>Submitted</Table.ColumnHeader>
+						<Table.ColumnHeader>Actions</Table.ColumnHeader>
+					</Table.Row>
+				</Table.Header>
+				<Table.Body>
+					{tools.map((tool) => (
+						<Table.Row key={tool._id} bg="tertiary">
+							<Table.Cell>
+								<Link href={tool.link} target="_blank">
+									{tool.name}
+								</Link>
+							</Table.Cell>
+							<Table.Cell>{tool.email}</Table.Cell>
+							<Table.Cell>{tool.compatibility ?? "—"}</Table.Cell>
+							<Table.Cell maxWidth="400px">
+								<Text lineClamp={2}>{tool.description}</Text>
+							</Table.Cell>
+							<Table.Cell whiteSpace="nowrap">
+								{new Date(tool.createdAt).toLocaleDateString("en-US", {
+									month: "short",
+									day: "numeric",
+									year: "numeric",
+								})}
+							</Table.Cell>
+							<Table.Cell>
+								<HStack gap={2}>
+									<Button
+										size="sm"
+										bg="green.500"
+										variant="subtle"
+										onClick={() => openDialog(tool, "approve")}
+									>
+										<LuCheck /> Approve
+									</Button>
+									<Button
+										size="sm"
+										bg="red.400"
+										variant="subtle"
+										onClick={() => openDialog(tool, "reject")}
+									>
+										<LuX /> Reject
+									</Button>
+								</HStack>
+							</Table.Cell>
+						</Table.Row>
+					))}
+				</Table.Body>
+			</Table.Root>
+
+			<Dialog.Root
+				open={!!selectedTool}
+				onOpenChange={({ open }) => {
+					if (!open) closeDialog();
+				}}
+			>
+				<Portal>
+					<Dialog.Backdrop />
+					<Dialog.Positioner>
+						<Dialog.Content>
+							<Dialog.Header>
+								<Dialog.Title>{action === "approve" ? "Approve Tool" : "Reject Tool"}</Dialog.Title>
+							</Dialog.Header>
+							<Dialog.Body>
+								<Text>
+									Are you sure you want to{" "}
+									<Badge colorScheme={action === "approve" ? "green" : "red"}>{action}</Badge>{" "}
+									<strong>{selectedTool?.name}</strong>?
+									{action === "reject" &&
+										" This will mark it as rejected and hide it from the public index."}
+								</Text>
+							</Dialog.Body>
+							<Dialog.Footer>
+								<Button variant="ghost" onClick={closeDialog} disabled={submitting}>
+									Cancel
+								</Button>
+								<Button
+									colorScheme={action === "approve" ? "green" : "red"}
+									onClick={handleConfirm}
+									loading={submitting}
+								>
+									Confirm {action === "approve" ? "Approval" : "Rejection"}
+								</Button>
+							</Dialog.Footer>
+						</Dialog.Content>
+					</Dialog.Positioner>
+				</Portal>
+			</Dialog.Root>
+		</>
+	);
+}
 
 function AdminPage() {
 	return (
-		<Stack>
+		<Stack gap={6}>
 			<Heading size="4xl">Admin</Heading>
-			<Text>You're an admin!</Text>
+			<Tabs.Root defaultValue="tools">
+				<Tabs.List>
+					<Tabs.Trigger value="tools">Tool Approvals</Tabs.Trigger>
+				</Tabs.List>
+				<Tabs.Content value="tools" pt={4}>
+					<ToolModerationTab />
+				</Tabs.Content>
+			</Tabs.Root>
 		</Stack>
 	);
 }

--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -1,7 +1,7 @@
-import { Badge, Button, Dialog, Heading, HStack, Link, Portal, Stack, Table, Tabs, Text } from "@chakra-ui/react";
+import { Badge, Box, Button, Dialog, Heading, HStack, Link, Portal, Stack, Table, Tabs, Text } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { LuCheck, LuX } from "react-icons/lu";
-import { api } from "@/lib/utils";
+import { api, decodeEntities } from "@/lib/utils";
 
 interface PendingTool {
 	_id: string;
@@ -11,6 +11,11 @@ interface PendingTool {
 	link: string;
 	email: string;
 	compatibility?: string;
+	videos?: string;
+	guidelines?: string;
+	limits?: string;
+	comments?: string;
+	isCreator?: boolean;
 	createdAt: string;
 }
 
@@ -22,13 +27,12 @@ function ToolModerationTab() {
 	const [selectedTool, setSelectedTool] = useState<PendingTool | null>(null);
 	const [action, setAction] = useState<ActionType | null>(null);
 	const [submitting, setSubmitting] = useState(false);
+	const [detailTool, setDetailTool] = useState<PendingTool | null>(null);
 
 	useEffect(() => {
 		const fetchPending = async () => {
 			try {
-				const res = await fetch(api("/api/admin/tools/pending"), {
-					credentials: "include",
-				});
+				const res = await fetch(api("/api/admin/tools/pending"), { credentials: "include" });
 				const data = await res.json();
 				setTools(data);
 			} catch (err) {
@@ -37,7 +41,6 @@ function ToolModerationTab() {
 				setLoading(false);
 			}
 		};
-
 		fetchPending();
 	}, []);
 
@@ -78,31 +81,19 @@ function ToolModerationTab() {
 					<Table.Row bg="secondary">
 						<Table.ColumnHeader>Name</Table.ColumnHeader>
 						<Table.ColumnHeader>Submitted By</Table.ColumnHeader>
-						<Table.ColumnHeader>Compatibility</Table.ColumnHeader>
-						<Table.ColumnHeader>Description</Table.ColumnHeader>
-						<Table.ColumnHeader>Submitted</Table.ColumnHeader>
+						<Table.ColumnHeader>Details</Table.ColumnHeader>
 						<Table.ColumnHeader>Actions</Table.ColumnHeader>
 					</Table.Row>
 				</Table.Header>
 				<Table.Body>
 					{tools.map((tool) => (
 						<Table.Row key={tool._id} bg="tertiary">
-							<Table.Cell>
-								<Link href={tool.link} target="_blank">
-									{tool.name}
-								</Link>
-							</Table.Cell>
+							<Table.Cell>{tool.name}</Table.Cell>
 							<Table.Cell>{tool.email}</Table.Cell>
-							<Table.Cell>{tool.compatibility ?? "—"}</Table.Cell>
-							<Table.Cell maxWidth="400px">
-								<Text lineClamp={2}>{tool.description}</Text>
-							</Table.Cell>
-							<Table.Cell whiteSpace="nowrap">
-								{new Date(tool.createdAt).toLocaleDateString("en-US", {
-									month: "short",
-									day: "numeric",
-									year: "numeric",
-								})}
+							<Table.Cell>
+								<Button variant="subtle" size="sm" onClick={() => setDetailTool(tool)}>
+									More Details
+								</Button>
 							</Table.Cell>
 							<Table.Cell>
 								<HStack gap={2}>
@@ -128,6 +119,80 @@ function ToolModerationTab() {
 					))}
 				</Table.Body>
 			</Table.Root>
+
+			<Dialog.Root
+				open={!!detailTool}
+				onOpenChange={({ open }) => {
+					if (!open) setDetailTool(null);
+				}}
+			>
+				<Portal>
+					<Dialog.Backdrop />
+					<Dialog.Positioner>
+						<Dialog.Content maxWidth="600px">
+							<Dialog.Header>
+								<Dialog.Title>{detailTool?.name}</Dialog.Title>
+							</Dialog.Header>
+							<Dialog.Body>
+								<Stack gap={4}>
+									<Box>
+										<Text fontWeight="bold" mb={1}>
+											Description
+										</Text>
+										<Text>{detailTool?.description}</Text>
+									</Box>
+									{[
+										{
+											label: "Link",
+											value: detailTool?.link ? decodeEntities(detailTool.link) : undefined,
+										},
+										{ label: "Submitted By", value: detailTool?.email },
+										{ label: "Compatibility", value: detailTool?.compatibility },
+										{ label: "Videos", value: detailTool?.videos },
+										{ label: "Guidelines", value: detailTool?.guidelines },
+										{ label: "Limits", value: detailTool?.limits },
+										{ label: "Comments", value: detailTool?.comments },
+										{ label: "Is Creator", value: detailTool?.isCreator ? "Yes" : "No" },
+										{
+											label: "Submitted",
+											value: detailTool
+												? new Date(detailTool.createdAt).toLocaleString("en-US", {
+														month: "long",
+														day: "numeric",
+														year: "numeric",
+														hour: "numeric",
+														minute: "2-digit",
+														hour12: true,
+													})
+												: undefined,
+										},
+									].map(({ label, value }) =>
+										value ? (
+											<Box key={label}>
+												<Text fontWeight="bold" mb={1}>
+													{label}
+												</Text>
+												{label === "Link" ? (
+													<Link href={value} target="_blank" color="blue.400">
+														{value}
+													</Link>
+												) : (
+													<Text>{value}</Text>
+												)}
+											</Box>
+										) : null,
+									)}
+								</Stack>
+							</Dialog.Body>
+							<Dialog.Footer>
+								<Button variant="ghost" onClick={() => setDetailTool(null)}>
+									Close
+								</Button>
+							</Dialog.Footer>
+						</Dialog.Content>
+					</Dialog.Positioner>
+				</Portal>
+			</Dialog.Root>
 
 			<Dialog.Root
 				open={!!selectedTool}

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -2,6 +2,7 @@ import { toNodeHandler } from "better-auth/node";
 import express from "express";
 import { auth } from "./auth";
 import apiRouter from "./routes/api";
+import adminRouter from "./routes/api/admin/tools";
 import "dotenv/config";
 import cors from "cors";
 import { initializeDatabase } from "./db";
@@ -35,6 +36,7 @@ app.all("/api/auth/*splat", toNodeHandler(auth));
 app.use(express.json({ limit: "4mb" }));
 app.use(express.urlencoded({ extended: true }));
 app.use("/api", apiRouter);
+app.use("/api/admin", adminRouter);
 
 app.listen(port, "0.0.0.0", () => {
 	console.log(`ACH Server listening on port ${port}`);

--- a/packages/server/routes/api/admin/tools.ts
+++ b/packages/server/routes/api/admin/tools.ts
@@ -1,0 +1,46 @@
+import { Router } from "express";
+import { auth } from "../../../auth";
+import { approveTool, getToolsByApprovalStatus, rejectTool } from "../../../schema/tool";
+
+const router = Router();
+
+router.use(async (req, res, next) => {
+	const session = await auth.api.getSession({ headers: req.headers });
+	if (!session) return res.status(401).send("Unauthorized");
+
+	const role = session.user.role as string;
+	if (!["admin", "moderator"].includes(role)) return res.status(403).send("Forbidden");
+
+	next();
+});
+
+router.get("/tools/pending", async (_req, res) => {
+	try {
+		const tools = await getToolsByApprovalStatus(null);
+		return res.status(200).json(tools);
+	} catch (err) {
+		return res.status(500).send(err);
+	}
+});
+
+router.post("/tools/:slug/approve", async (req, res) => {
+	try {
+		const tool = await approveTool(req.params.slug);
+		if (!tool) return res.status(404).json({ message: "Tool not found" });
+		return res.status(200).json(tool);
+	} catch (err) {
+		return res.status(500).send(err);
+	}
+});
+
+router.post("/tools/:slug/reject", async (req, res) => {
+	try {
+		const tool = await rejectTool(req.params.slug);
+		if (!tool) return res.status(404).json({ message: "Tool not found" });
+		return res.status(200).json(tool);
+	} catch (err) {
+		return res.status(500).send(err);
+	}
+});
+
+export default router;

--- a/packages/server/schema/tool.ts
+++ b/packages/server/schema/tool.ts
@@ -1,4 +1,4 @@
-import mongoose, { type InferSchemaType, type Types } from "mongoose";
+import mongoose, { type InferSchemaType, type PipelineStage, type Types } from "mongoose";
 import slugify from "slugify";
 
 export const toolFormSchema = new mongoose.Schema(
@@ -20,6 +20,7 @@ export const toolFormSchema = new mongoose.Schema(
 			unique: true,
 			index: true,
 		},
+		approved: { type: Boolean, default: null, index: true },
 	},
 	{
 		timestamps: true,
@@ -147,8 +148,24 @@ export const getReviewByUser = async (userId: string, toolId: Types.ObjectId | s
 	return ToolReviewModel.findOne({ userId, toolId }).lean();
 };
 
-export const getToolsWithRatings = async () => {
+export const approveTool = async (slug: string) => {
+	return ToolFormModel.findOneAndUpdate({ slug }, { approved: true }, { new: true });
+};
+
+export const rejectTool = async (slug: string) => {
+	return ToolFormModel.findOneAndUpdate({ slug }, { approved: false }, { new: true });
+};
+
+export const getToolsWithRatings = async (filter: "approved" | "pending" | "rejected" | "all" = "approved") => {
+	const matchStages: PipelineStage[] = {
+		approved: [{ $match: { approved: true } }],
+		pending: [{ $match: { approved: null } }],
+		rejected: [{ $match: { approved: false } }],
+		all: [],
+	}[filter];
+
 	return ToolFormModel.aggregate([
+		...matchStages,
 		{
 			$lookup: {
 				from: "toolreviews",
@@ -166,4 +183,8 @@ export const getToolsWithRatings = async () => {
 		{ $unset: "reviews" },
 		{ $sort: { createdAt: -1 } },
 	]);
+};
+
+export const getToolsByApprovalStatus = async (status: true | false | null) => {
+	return ToolFormModel.find({ approved: status }).sort({ createdAt: -1 }).lean();
 };


### PR DESCRIPTION
Modifies tool schema to add an approved, pending (null), or rejected (TBD on if these tools should simply be removed from the DB altogether) state. Adds a tab view in the admin page to view pending tools and take action on them.

Closes #58 
